### PR TITLE
fix: remove ES module export to ensure CommonJS compatibility with Strapi

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,9 @@
-import defaultExport from "../index";
 import { ProviderOptions } from "../index.types";
 import { MinioProvider } from "../provider/minio-provider";
 import { ConfigurationError } from "../errors/provider-errors";
+
+// Import as CommonJS module (as Strapi does)
+const defaultExport = require("../index");
 
 describe("index", () => {
   const validConfig: ProviderOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,6 @@ const provider = {
   },
 };
 
-// Export for ES modules
-export default provider;
-
 // Export for CommonJS (required by Strapi)
-// This ensures compatibility with both ES modules and CommonJS
+// This must be the primary export for Strapi to work correctly
 module.exports = provider;


### PR DESCRIPTION
English | [pt-BR](#-português)

---

## 🇺🇸 English

### Description

This PR removes the ES module export (`export default`) from `src/index.ts` to ensure full compatibility with CommonJS, which is the format required by Strapi for upload providers.

### Changes

- Removed `export default provider` from `src/index.ts`
- Kept only `module.exports = provider` (CommonJS format)
- Fixed test `src/__tests__/index.test.ts` to use `require()` instead of `import default`

### Motivation

The error `TypeError: strapi.plugin(...).provider.upload is not a function` was occurring because Strapi expects the provider to be exported exclusively in CommonJS format. The dual export (ES module + CommonJS) was causing issues when Strapi imported the module.

### Tests

- ✅ All tests passing
- ✅ CommonJS import test updated and working

### Checklist

- [x] Code follows project standards
- [x] Tests passing
- [x] Commits follow conventional commits pattern

---

## 🇧🇷 Português

### Descrição

Este PR remove a exportação ES module (`export default`) do arquivo `src/index.ts` para garantir compatibilidade total com CommonJS, que é o formato exigido pelo Strapi para providers de upload.

### Mudanças

- Removido `export default provider` de `src/index.ts`
- Mantido apenas `module.exports = provider` (formato CommonJS)
- Corrigido teste `src/__tests__/index.test.ts` para usar `require()` ao invés de `import default`

### Motivação

O erro `TypeError: strapi.plugin(...).provider.upload is not a function` estava ocorrendo porque o Strapi espera que o provider seja exportado exclusivamente em formato CommonJS. A exportação dupla (ES module + CommonJS) estava causando problemas na importação do módulo pelo Strapi.

### Testes

- ✅ Todos os testes passando
- ✅ Teste de importação CommonJS atualizado e funcionando

### Checklist

- [x] Código segue os padrões do projeto
- [x] Testes passando
- [x] Commits seguem o padrão conventional commits