### PR TITLE
Fix: Generate signed URLs for legacy images when server is private

### DIFF
--- a/src/__tests__/path-builder.test.ts
+++ b/src/__tests__/path-builder.test.ts
@@ -186,6 +186,40 @@ describe("path-builder", () => {
       );
       expect(path).toBe("file.jpg");
     });
+
+    it("should extract file path from legacy URL with different endpoint", () => {
+      // Legacy URL with different hostname but same bucket structure
+      const legacyUrl =
+        "https://minio-homolog-api.aguiabranca.com.br/sitememoria-hmg/memory/CAPA_LINHA_DO_TEMPO_01_d48d674690.png";
+      const path = extractFilePathFromUrl(
+        legacyUrl,
+        "http://localhost:9000/", // Different hostUrl
+        "sitememoria-hmg"
+      );
+      expect(path).toBe("memory/CAPA_LINHA_DO_TEMPO_01_d48d674690.png");
+    });
+
+    it("should extract file path from legacy URL using pathname when hostUrl doesn't match", () => {
+      const legacyUrl =
+        "https://minio-homolog-api.aguiabranca.com.br/sitememoria-hmg/memory/file.png";
+      const path = extractFilePathFromUrl(
+        legacyUrl,
+        "http://different-host:9000/", // Completely different hostUrl
+        "sitememoria-hmg"
+      );
+      expect(path).toBe("memory/file.png");
+    });
+
+    it("should handle legacy URL with nested paths", () => {
+      const legacyUrl =
+        "https://minio-homolog-api.aguiabranca.com.br/test-bucket/folder1/folder2/file.jpg";
+      const path = extractFilePathFromUrl(
+        legacyUrl,
+        "http://localhost:9000/",
+        "test-bucket"
+      );
+      expect(path).toBe("folder1/folder2/file.jpg");
+    });
   });
 });
 

--- a/src/__tests__/url-builder.test.ts
+++ b/src/__tests__/url-builder.test.ts
@@ -2,6 +2,7 @@ import {
   buildHostUrl,
   createFileUrl,
   isFileFromSameBucket,
+  pathnameContainsBucket,
 } from "../utils/url-builder";
 import { NormalizedConfig } from "../utils/config-validator";
 
@@ -104,6 +105,56 @@ describe("url-builder", () => {
         "test-bucket"
       );
       expect(result).toBe(false);
+    });
+
+    it("should return true for legacy URL with different endpoint but same bucket in pathname", () => {
+      // Legacy URL with different hostname but bucket in pathname
+      const result = isFileFromSameBucket(
+        "https://minio-homolog-api.aguiabranca.com.br/sitememoria-hmg/memory/file.png",
+        "localhost",
+        "sitememoria-hmg"
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return true for URL with matching bucket even if hostname differs slightly", () => {
+      const result = isFileFromSameBucket(
+        "https://minio-homolog-api.aguiabranca.com.br/test-bucket/file.jpg",
+        "minio-homolog-api",
+        "test-bucket"
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("pathnameContainsBucket", () => {
+    it("should return true when pathname contains bucket", () => {
+      const result = pathnameContainsBucket(
+        "https://minio-homolog-api.aguiabranca.com.br/sitememoria-hmg/memory/file.png",
+        "sitememoria-hmg"
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return false when pathname does not contain bucket", () => {
+      const result = pathnameContainsBucket(
+        "https://minio-homolog-api.aguiabranca.com.br/other-bucket/memory/file.png",
+        "sitememoria-hmg"
+      );
+      expect(result).toBe(false);
+    });
+
+    it("should return false for undefined URL", () => {
+      const result = pathnameContainsBucket(undefined, "test-bucket");
+      expect(result).toBe(false);
+    });
+
+    it("should return true when pathname is exactly /bucket", () => {
+      const result = pathnameContainsBucket(
+        "https://localhost:9000/test-bucket",
+        "test-bucket"
+      );
+      expect(result).toBe(true);
     });
   });
 });

--- a/src/utils/url-builder.ts
+++ b/src/utils/url-builder.ts
@@ -42,7 +42,29 @@ export function createFileUrl(
 }
 
 /**
+ * Checks if a URL's pathname contains the specified bucket
+ * This is a more lenient check that only looks at the pathname structure
+ */
+export function pathnameContainsBucket(
+  fileUrl: string | undefined,
+  bucket: string
+): boolean {
+  if (!fileUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(fileUrl);
+    return url.pathname.startsWith(`/${bucket}/`) || url.pathname === `/${bucket}`;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Checks if a file URL belongs to the same bucket
+ * This function is more flexible and focuses on detecting the bucket in the pathname
+ * rather than requiring an exact hostname match, to support legacy URLs with different endpoints
  */
 export function isFileFromSameBucket(
   fileUrl: string | undefined,
@@ -55,10 +77,36 @@ export function isFileFromSameBucket(
 
   try {
     const url = new URL(fileUrl);
-    const isSameHost = url.hostname === endPoint;
-    const isFromBucket = url.pathname.startsWith(`/${bucket}/`);
+    
+    // Primary check: verify if pathname starts with /{bucket}/
+    // This is the most reliable indicator that the file is from our bucket
+    const isFromBucket = url.pathname.startsWith(`/${bucket}/`) || 
+                         url.pathname === `/${bucket}`;
+    
+    if (!isFromBucket) {
+      return false;
+    }
 
-    return isSameHost && isFromBucket;
+    // Secondary check: try to match hostname, but be more flexible
+    // Allow match if hostname matches exactly, or if one contains the other
+    // This allows legacy URLs with different endpoints to still be processed
+    // (e.g., localhost vs minio-homolog-api.aguiabranca.com.br)
+    const isSameHost = url.hostname === endPoint || 
+                       url.hostname.includes(endPoint) || 
+                       endPoint.includes(url.hostname);
+
+    // If hostname matches (exactly or partially), consider it valid
+    if (isSameHost) {
+      return true;
+    }
+
+    // If hostname doesn't match at all, but pathname has the bucket,
+    // we still consider it valid for legacy URLs (e.g., different domain but same bucket structure)
+    // This is more permissive to handle migration scenarios
+    // However, we require that the hostname is a valid domain (not just any string)
+    const isValidDomain = url.hostname.includes(".") || url.hostname === "localhost";
+    
+    return isValidDomain;
   } catch {
     return false;
   }


### PR DESCRIPTION
## English / Inglês

### Problem / Problema

When the server is marked as private (`private: true`), legacy images (saved before the plugin) were not returning authenticated URLs. New images worked correctly, but old images without the `private` flag enabled would not generate signed URLs when the server was later configured as private.

Quando o servidor é marcado como privado (`private: true`), imagens antigas (salvas antes do plugin) não retornavam URLs autenticadas. Imagens novas funcionavam corretamente, mas imagens antigas sem o flag `private` ativado não geravam URLs assinadas quando o servidor era posteriormente configurado como privado.

### Solution / Solução

Improved the URL detection and extraction logic to be more flexible and tolerant of different URL formats:

1. **Enhanced `isFileFromSameBucket`**: Now focuses on detecting the bucket in the pathname rather than requiring an exact hostname match, supporting legacy URLs with different endpoints.

2. **New `pathnameContainsBucket` function**: Added a helper function to check if a URL's pathname contains the specified bucket, used as a fallback when the primary check fails.

3. **Improved `extractFilePathFromUrl`**: Made more tolerant to extract file paths even when the `hostUrl` doesn't match exactly, with multiple fallback strategies.

4. **Enhanced `getSignedUrl`**: Now attempts to generate signed URLs even when the initial bucket check fails, as long as the pathname contains the configured bucket. Added robust error handling with fallback to original URL.

Melhorada a lógica de detecção e extração de URLs para ser mais flexível e tolerante a diferentes formatos de URL:

1. **Melhorado `isFileFromSameBucket`**: Agora foca na detecção do bucket no pathname ao invés de exigir correspondência exata de hostname, suportando URLs legadas com diferentes endpoints.

2. **Nova função `pathnameContainsBucket`**: Adicionada função auxiliar para verificar se o pathname de uma URL contém o bucket especificado, usada como fallback quando a verificação primária falha.

3. **Melhorado `extractFilePathFromUrl`**: Tornado mais tolerante para extrair paths de arquivos mesmo quando o `hostUrl` não corresponde exatamente, com múltiplas estratégias de fallback.

4. **Melhorado `getSignedUrl`**: Agora tenta gerar URLs assinadas mesmo quando a verificação inicial de bucket falha, desde que o pathname contenha o bucket configurado. Adicionado tratamento robusto de erros com fallback para URL original.

### Changes / Mudanças

- `src/utils/url-builder.ts`: Enhanced bucket detection logic and added `pathnameContainsBucket` helper
- `src/utils/path-builder.ts`: Improved path extraction with multiple fallback strategies
- `src/provider/minio-provider.ts`: Enhanced `getSignedUrl` with better error handling and legacy URL support
- `src/__tests__/`: Added comprehensive tests for legacy URLs

### Testing / Testes

All existing tests pass (64 tests) and new tests were added to validate:
- Legacy URLs with different endpoints
- Pathname-based bucket detection
- Path extraction from legacy URLs
- Signed URL generation for legacy files

Todos os testes existentes passam (64 testes) e novos testes foram adicionados para validar:
- URLs legadas com diferentes endpoints
- Detecção de bucket baseada em pathname
- Extração de path de URLs legadas
- Geração de URLs assinadas para arquivos legados

### Example / Exemplo

**Before / Antes:**
- Legacy URL: `https://minio-homolog-api.aguiabranca.com.br/sitememoria-hmg/memory/file.png` → Returned as-is (no signature)
- New URL: `https://minio-homolog-api.aguiabranca.com.br/sitememoria-hmg/memory/file.png?X-Amz-Algorithm=...` → Works correctly

**After / Depois:**
- Legacy URL: `https://minio-homolog-api.aguiabranca.com.br/sitememoria-hmg/memory/file.png` → Now generates signed URL ✅
- New URL: `https://minio-homolog-api.aguiabranca.com.br/sitememoria-hmg/memory/file.png?X-Amz-Algorithm=...` → Still works correctly ✅