### PR TITLE
feat: add configurable connection and request timeouts support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ MINIO_FOLDER=cms
 MINIO_PRIVATE=false
 # Expiry time for signed URLs in seconds (default: 604800 = 7 days)
 MINIO_EXPIRY=604800
+# Connection timeout in milliseconds (default: 60000 = 60 seconds)
+MINIO_CONNECT_TIMEOUT=60000
+# Request timeout in milliseconds (optional, for future use)
+# MINIO_REQUEST_TIMEOUT=300000
 
 # ===========================================
 # Example for Docker/MinIO Setup

--- a/README.md
+++ b/README.md
@@ -122,17 +122,19 @@ await strapi.plugin('upload').provider.upload(file, {
 
 ## 🔧 Configuration options
 
-| Option      | Type   | Required | Description                                 |
-|-------------|--------|----------|---------------------------------------------|
-| `endPoint`  | string | ✅       | MinIO server endpoint                       |
-| `port`      | number | ❌       | Server port (default: 9000 for HTTP, 443 for HTTPS) |
-| `useSSL`    | boolean| ❌       | Use HTTPS (default: false)                  |
-| `accessKey` | string | ✅       | MinIO access key                            |
-| `secretKey` | string | ✅       | MinIO secret key                            |
-| `bucket`    | string | ✅       | Bucket name to store files                  |
-| `folder`    | string | ❌       | Folder inside the bucket (optional)         |
-| `private`   | boolean| ❌       | Enable private file uploads (default: false) |
-| `expiry`    | number | ❌       | Signed URL expiry in seconds (default: 604800 = 7 days) |
+| Option           | Type   | Required | Description                                 |
+|------------------|--------|----------|---------------------------------------------|
+| `endPoint`       | string | ✅       | MinIO server endpoint                       |
+| `port`           | number | ❌       | Server port (default: 9000 for HTTP, 443 for HTTPS) |
+| `useSSL`         | boolean| ❌       | Use HTTPS (default: false)                  |
+| `accessKey`      | string | ✅       | MinIO access key                            |
+| `secretKey`      | string | ✅       | MinIO secret key                            |
+| `bucket`         | string | ✅       | Bucket name to store files                  |
+| `folder`         | string | ❌       | Folder inside the bucket (optional)         |
+| `private`        | boolean| ❌       | Enable private file uploads (default: false) |
+| `expiry`         | number | ❌       | Signed URL expiry in seconds (default: 604800 = 7 days) |
+| `connectTimeout` | number | ❌       | Connection timeout in milliseconds (default: 60000 = 60 seconds) |
+| `requestTimeout` | number | ❌       | Request timeout in milliseconds (optional, for future use) |
 
 ## 🐳 Docker Compose - MinIO for development
 

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -60,6 +60,8 @@ export interface ProviderOptions {
   folder?: string;
   private?: boolean | string;
   expiry?: number | string;
+  connectTimeout?: number | string; // Connection timeout in milliseconds
+  requestTimeout?: number | string; // Request timeout in milliseconds (optional, for future use)
 }
 
 export interface SignedUrlResponse {

--- a/src/provider/minio-client-factory.ts
+++ b/src/provider/minio-client-factory.ts
@@ -1,16 +1,35 @@
 import { Client as MinioClient } from "minio";
+import http from "http";
+import https from "https";
 import { NormalizedConfig } from "../utils/config-validator";
 
 /**
  * Creates a MinIO client instance from configuration
  */
 export function createMinioClient(config: NormalizedConfig): MinioClient {
-  return new MinioClient({
+  const clientOptions: any = {
     endPoint: config.endPoint,
     port: config.port,
     useSSL: config.useSSL,
     accessKey: config.accessKey,
     secretKey: config.secretKey,
-  });
+  };
+
+  // Create custom HTTP agent with timeout options if provided
+  const connectTimeout = config.connectTimeout || 60000; // Default 60 seconds
+
+  const agentOptions = {
+    keepAlive: true,
+    keepAliveMsecs: 1000,
+    timeout: connectTimeout,
+  };
+
+  if (config.useSSL) {
+    clientOptions.transportAgent = new https.Agent(agentOptions);
+  } else {
+    clientOptions.transportAgent = new http.Agent(agentOptions);
+  }
+
+  return new MinioClient(clientOptions);
 }
 


### PR DESCRIPTION
## 🎯 Objetivo

Adiciona suporte a timeouts configuráveis de conexão e requisição no provider MinIO para resolver erros `ETIMEDOUT` em conexões lentas ou instáveis.

## ✨ Mudanças

### Novas funcionalidades
- ✅ Suporte a `connectTimeout` configurável (padrão: 60000ms = 60 segundos)
- ✅ Suporte a `requestTimeout` configurável (reservado para uso futuro)
- ✅ HTTP agents customizados com timeouts para HTTP e HTTPS
- ✅ Validação e normalização de valores de timeout
- ✅ Documentação completa das novas opções

### Arquivos modificados
- `src/index.types.ts` - Adicionadas interfaces para timeouts
- `src/utils/config-validator.ts` - Validação e normalização de timeouts
- `src/provider/minio-client-factory.ts` - Implementação de HTTP agents com timeouts
- `src/__tests__/config-validator.test.ts` - Testes para validação de timeouts
- `README.md` - Documentação das novas opções
- `.env.example` - Exemplos de variáveis de ambiente

## 🧪 Testes

- ✅ Todos os testes passando (113 testes)
- ✅ 6 novos testes adicionados para validação de `connectTimeout`
- ✅ Sem erros de TypeScript
- ✅ Sem erros de lint

## 📝 Detalhes técnicos

### Configuração
```typescript
providerOptions: {
  // ... outras opções ...
  connectTimeout: 60000, // 60 segundos (padrão)
  requestTimeout: 300000, // 5 minutos (opcional)
}
```

### HTTP Agents
- Suporte para HTTP e HTTPS
- `keepAlive: true` para reutilização de conexões
- `timeout` configurável baseado em `connectTimeout`

## 🔍 Como testar

1. Configure o `connectTimeout` no `config/plugins.ts`:
```typescript
connectTimeout: env.int('MINIO_CONNECT_TIMEOUT', 60 * 1000)
```

2. Teste com conexões lentas ou instáveis
3. Verifique que os erros `ETIMEDOUT` são reduzidos ou eliminados

## 📚 Documentação

A documentação foi atualizada no README.md com:
- Tabela de opções de configuração atualizada
- Descrição dos valores padrão
- Unidades (milissegundos)